### PR TITLE
Blacklist test instead of stopping if bench fails.

### DIFF
--- a/Client/worker.py
+++ b/Client/worker.py
@@ -1128,6 +1128,7 @@ def safe_run_benchmarks(config, branch, engine, network):
             binary, network, private, 1, 1, expected)
 
     except utils.OpenBenchBadBenchException as error:
+        config.blacklist.append(config.workload['test']['id'])
         ServerReporter.report_bad_bench(config, error.message)
         raise
 

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -682,10 +682,6 @@ def client_get_workload(request, machine):
 @verify_worker
 def client_bench_error(request, machine):
 
-    # Find and stop the test with the bad bench
-    test = Test.objects.get(id=int(request.POST['test_id']))
-    test.finished = True; test.save()
-
     # Log the error into the Events table
     LogEvent.objects.create(
         author     = machine.user.username,


### PR DESCRIPTION
There is fairly common case that a worker has GPU problems. GPU problems will cause a bench failure. Reporting of bench failure stops the test. This is different to how compile errors are handled using client blacklist. This change makes bench error handle the same as compile errors.